### PR TITLE
Create full mount function

### DIFF
--- a/PoshBot.Rubrik/Public/New-PBRubrikFullMount.ps1
+++ b/PoshBot.Rubrik/Public/New-PBRubrikFullMount.ps1
@@ -1,0 +1,33 @@
+function New-PBRubrikFullMount {
+    [PoshBot.BotCommand(
+        CommandName = 'rubrik_fullmount',
+        Aliases = 'fullmount'
+    )]
+    [cmdletbinding()]
+    param(
+        [PoshBot.FromConfig()]
+        [parameter(Mandatory)]
+        [hashtable]$Connection,
+        [int]$Snapshot,
+        [ValidateSet('vm')]
+        [string]$Type,
+        [string]$Id
+    )
+
+    $creds = [pscredential]::new($Connection.Username, ($Connection.Password | ConvertTo-SecureString -AsPlainText -Force))
+    $null = Connect-Rubrik -Server $Connection.Server -Credential $creds
+
+    $params = $PSBoundParameters
+    $params.Remove('Connection') | Out-Null
+
+    switch ($type) {
+        'vm' {$objects = (Get-RubrikVM -id $Id | Get-RubrikSnapshot)[$Snapshot] | New-RubrikMount -PowerOn -Confirm:$false}
+    }
+
+    $ResponseSplat = @{
+        Text = Format-PBRubrikObject -Object $objects -FunctionName $MyInvocation.MyCommand.Name
+        AsCode = $true
+    }
+
+    New-PoshBotTextResponse @ResponseSplat
+}

--- a/Tests/New-PBRubrikFullMount.tests.ps1
+++ b/Tests/New-PBRubrikFullMount.tests.ps1
@@ -1,0 +1,46 @@
+Remove-Module -Name 'PoshBot.Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './PoshBot.Rubrik/PoshBot.Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './PoshBot.Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/New-PBRubrikFullMount' -Tag 'Public', 'New-PBRubrikFullMount' -Fixture {
+#region Specific formatting
+$Connection = @{
+    Server   = '1.1.1.1'
+    Username = 'RoxieAtRubrik'
+    Password = 'KnowItAll'
+}
+#endregion
+
+    Context -Name 'Parameter/NewFullMount' {
+        Mock -CommandName Connect-Rubrik -Verifiable -ModuleName 'PoshBot.Rubrik' -MockWith {}
+        Mock -CommandName Get-RubrikVM -Verifiable -ModuleName 'PoshBot.Rubrik' -MockWith {
+            [pscustomobject]@{
+                id = '1-1-1-1'
+            }
+        }
+        Mock -CommandName Get-RubrikSnapshot -Verifiable -ModuleName 'PoshBot.Rubrik' -MockWith {
+            [pscustomobject]@{
+                id = '2-2-2-2'
+            }
+        }
+        Mock -CommandName New-RubrikMount -Verifiable -ModuleName 'PoshBot.Rubrik' -MockWith {
+            [pscustomobject]@{
+                id = '3-3-3-3'
+            }
+        }
+
+        It -Name 'Run with basic parameters' -Test {
+            (New-PBRubrikFullMount -id '1-1-1-1' -type 'vm' -snapshot 0 -Connection $Connection).Text |
+                Should -Be 'id : 3-3-3-3'
+        }
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Connect-Rubrik -ModuleName 'PoshBot.Rubrik' -Times 1
+        Assert-MockCalled -CommandName Get-RubrikVM -ModuleName 'PoshBot.Rubrik' -Times 1
+        Assert-MockCalled -CommandName Get-RubrikSnapshot -ModuleName 'PoshBot.Rubrik' -Times 1
+        Assert-MockCalled -CommandName New-RubrikMount -ModuleName 'PoshBot.Rubrik' -Times 1
+    }
+}


### PR DESCRIPTION
## Description
It's a bit tedious to have to get a VM id, then snapshot id(s), and then mount the snapshot. The `fullmount` function allows you to skip all that by providing the object id, the snapshot number, and the type of object (just `vm` for now).

## Motivation and Context
 Easier for folks to make live mounts.

## How Has This Been Tested?
Tested using 5.0.0.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

